### PR TITLE
fix bug of unparsed flags

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ func main() {
 	var configFile, geoipdb string
 	flag.StringVar(&configFile, "s", "flora.default.conf", "specify surge config file")
 	flag.StringVar(&geoipdb, "d", "geoip.mmdb", "specify geoip db file")
+	flag.Parse()
 	flora.Run(configFile, geoipdb)
 
 }


### PR DESCRIPTION
The configFile and geoip were bound to flag, but flag.Parse was not called.